### PR TITLE
MIN_VALUE has different semantics for floating point types than integer types

### DIFF
--- a/RTree.java
+++ b/RTree.java
@@ -141,7 +141,7 @@ public class RTree {
 			else
 				list = n.children;
 
-			float maxD = Float.MIN_VALUE;
+			float maxD = -Float.MAX_VALUE;
 			RectF box = new RectF();
 			for (int i = 0; i < list.size(); i++) {
 				for (int j=0; j<list.size(); j++) {


### PR DESCRIPTION
Float.MIN_VALUE is the smallest positive Float value larger than 0, not the smallest Float value. 

The splitter has a further problem in that in the degenerate case: all objects in a leaf with the same bounding boxes, it will crash because seed1 and seed2 are null, these should simply be initialized to any two objects from the leaf.
